### PR TITLE
Update to use 4.x version of language server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,28 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "felixfbecker/language-server": "^3.1.0"
+        "felixfbecker/language-server": "^4.2.0"
+    },
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "JetBrains/phpstorm-stubs",
+                "version": "dev-master",
+                "dist": {
+                    "url": "https://github.com/JetBrains/phpstorm-stubs/archive/master.zip",
+                    "type": "zip"
+                },
+                "source": {
+                    "url": "https://github.com/JetBrains/phpstorm-stubs",
+                    "type": "git",
+                    "reference": "master"
+                }
+            }
+        }
+    ],
+    "scripts": {
+        "parse-stubs": "LanguageServer\\ComposerScripts::parseStubs",
+        "post-update-cmd": "@parse-stubs"
     }
 }


### PR DESCRIPTION
I just took a guess for the language server version, since using `4.1.0` throws errors :)