### PR TITLE
Enable fileEvents in client options

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,9 +94,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         },
         synchronize: {
             // Synchronize the setting section 'php' to the server
-            configurationSection: 'php'
-            // Notify the server about file changes to composer.json files contain in the workspace
-            // fileEvents: vscode.workspace.createFileSystemWatcher('**/composer.json')
+            configurationSection: 'php',
+            // Notify the server about changes to PHP files in the workspace
+            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.php')
         }
     };
 


### PR DESCRIPTION
This is necessary to notify the server about changes to PHP files in the workspace and receive workspace/file.

In accordance with https://github.com/felixfbecker/php-language-server/pull/319. Also, this should be updated to work with custom file types after https://github.com/felixfbecker/php-language-server/pull/308 is merged.