### PR TITLE
support pre-starting

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "url": "https://github.com/felixfbecker/php-language-server/issues"
   },
   "activationEvents": [
-    "onLanguage:php"
+    "onLanguage:php",
+    "workspaceContains:*.php"
   ],
   "main": "./out/extension",
   "scripts": {


### PR DESCRIPTION
New feature since May: https://github.com/Microsoft/vscode/issues/944

With this pull request, the extension is able to start before actually editing a file, so when you actually want editing a php file, everything is good to go!