### PR TITLE
Set a default memory limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,8 @@
       "properties": {
         "php.memoryLimit": {
           "type": "string",
-          "default": "-1",
-          "description": "The memory limit of the php language server. [Number][K|M|G]. Use '-1' to allow unlimited use of the RAM(default).",
+          "default": "4G",
+          "description": "The memory limit of the php language server. [Number][K|M|G]. Use '-1' to allow unlimited use of the RAM (default is 4G).",
           "pattern": "^\\d+[KMG]?$"
         },
         "php.executablePath": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const conf = vscode.workspace.getConfiguration('php');
     const executablePath = conf.get<string>('executablePath') || 'php';
 
-    const memoryLimit = conf.get<string>('memoryLimit') || '-1';
+    const memoryLimit = conf.get<string>('memoryLimit') || '4G';
 
     if (memoryLimit !== '-1' && !/^\d+[KMG]?$/.exec(memoryLimit)) {
         const selected = await vscode.window.showErrorMessage(


### PR DESCRIPTION
Thanks for intellisense support for PHP.

I too ran into issue #192, I noticed the language server has a different memory limit of 4 gigs [1] so I think that using the same limit is a reasonable default for this intellisense package.

🌮 

[1] https://github.com/felixfbecker/php-language-server/commit/f43ce50d5ab534581212e0abb74841d9fb18a90a