### PR TITLE
[Discussion] [Live Share] Restricting language services to file schemes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         // Register the server for php documents
-        documentSelector: ['php'],
+        documentSelector: [
+            { scheme: 'file', language: 'php' },
+            { scheme: 'untitled', language: 'php' }
+        ],
         uriConverters: {
             // VS Code by default %-encodes even the colon after the drive letter
             // NodeJS handles it much better


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](aka.ms/vsls) *(or other VS Code virtual file system providers)* adding support for "guests" to receive remote language services for PHP, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the PHP extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

If someone joins a PHP project using Live Share, and doesn't have the PHP extension installed, then they will automatically receive language services from the host (which is awesome! 🎉), so this PR is simply an optimization for the case where collaborating developers both have the PHP extension installed. Additionally, this wouldn't impact the "local" PHP development experience.

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*

// CC @felixfbecker 