### PR TITLE
docs(readme): npm command in README.md should be 'run build' not 'run…

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Clone whole repository and in root directory execute:
 ```bash
 composer install
 npm install
-npm run compile
+npm run build
 code .
 ```
 The last command will open the folder in VS Code. Hit `F5` to launch an Extension Development Host with the extension.


### PR DESCRIPTION
README.md led me on a little bit of a goose chase until I looked at `package.json` and realized the build script is `build` not `compile`.