### PR TITLE
Also exclude vendors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
 	"exclude": [
 		"node_modules",
     "out",
-    "vendor"
+    "vendor",
+    "vendors"
 	]
 }


### PR DESCRIPTION
Some PHP frameworks like CakePHP 2 uses vendors instead of vendor.