### PR TITLE
Fix local command execution issue closes #494

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // Check path (if PHP is available and version is ^7.0.0)
     let stdout: string
     try {
-        stdout = await execa.stdout(executablePath, ['--version'],{preferLocal: false})
+        stdout = await execa.stdout(executablePath, ['--version'], {preferLocal: false})
     } catch (err) {
         if (err.code === 'ENOENT') {
             const selected = await vscode.window.showErrorMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // Check path (if PHP is available and version is ^7.0.0)
     let stdout: string
     try {
-        stdout = await execa.stdout(executablePath, ['--version'])
+        stdout = await execa.stdout(executablePath, ['--version'],{preferLocal: false})
     } catch (err) {
         if (err.code === 'ENOENT') {
             const selected = await vscode.window.showErrorMessage(


### PR DESCRIPTION
This PR will fix a command execution issue in the extension.

`execa` version 1.0 used in this extension searches the local path first when trying to find the `php` executable. By this a crafted project can override the `php` binary and execute arbitrary code.